### PR TITLE
Fix log_softmax calls

### DIFF
--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -88,7 +88,7 @@ def create_training_function(mnist_dir_path: str) -> Callable:
             x = F.relu(self.fc1(x))
             x = F.dropout(x, training=self.training)
             x = self.fc2(x)
-            return F.log_softmax(x)
+            return F.log_softmax(x, dim=1)
 
     def train_fn(learning_rate: float) -> Any:
         import torch

--- a/python/test_support/test_pytorch_training_file.py
+++ b/python/test_support/test_pytorch_training_file.py
@@ -46,7 +46,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=1)
 
 
 def train_one_epoch(model, data_loader, optimizer, epoch):


### PR DESCRIPTION
## Summary
- specify dim for PyTorch's log_softmax in torch example tests

## Testing
- `./dev/lint-python --flake8`

------
https://chatgpt.com/codex/tasks/task_e_6869f53ed6b0832b82f6ee1562d84f3a